### PR TITLE
feat: add --bind-mount to remap host paths into the sandbox

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3771,7 +3771,7 @@ dependencies = [
 
 [[package]]
 name = "zerobox"
-version = "0.3.1"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3798,7 +3798,7 @@ dependencies = [
 
 [[package]]
 name = "zerobox-linux-sandbox"
-version = "0.3.1"
+version = "0.3.3"
 dependencies = [
  "clap",
  "globset",
@@ -3821,7 +3821,7 @@ dependencies = [
 
 [[package]]
 name = "zerobox-network-proxy"
-version = "0.3.1"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3852,14 +3852,14 @@ dependencies = [
 
 [[package]]
 name = "zerobox-otel"
-version = "0.3.1"
+version = "0.3.3"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "zerobox-process-hardening"
-version = "0.3.1"
+version = "0.3.3"
 dependencies = [
  "libc",
  "pretty_assertions",
@@ -3867,7 +3867,7 @@ dependencies = [
 
 [[package]]
 name = "zerobox-protocol"
-version = "0.3.1"
+version = "0.3.3"
 dependencies = [
  "globset",
  "pretty_assertions",
@@ -3884,7 +3884,7 @@ dependencies = [
 
 [[package]]
 name = "zerobox-sandboxing"
-version = "0.3.1"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3905,7 +3905,7 @@ dependencies = [
 
 [[package]]
 name = "zerobox-snapshot"
-version = "0.3.1"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "blake3",
@@ -3924,7 +3924,7 @@ dependencies = [
 
 [[package]]
 name = "zerobox-utils-absolute-path"
-version = "0.3.1"
+version = "0.3.3"
 dependencies = [
  "dirs",
  "dunce",
@@ -3938,7 +3938,7 @@ dependencies = [
 
 [[package]]
 name = "zerobox-utils-home-dir"
-version = "0.3.1"
+version = "0.3.3"
 dependencies = [
  "dirs",
  "zerobox-utils-absolute-path",
@@ -3946,7 +3946,7 @@ dependencies = [
 
 [[package]]
 name = "zerobox-utils-pty"
-version = "0.3.1"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "filedescriptor",
@@ -3962,14 +3962,14 @@ dependencies = [
 
 [[package]]
 name = "zerobox-utils-rustls-provider"
-version = "0.3.1"
+version = "0.3.3"
 dependencies = [
  "rustls",
 ]
 
 [[package]]
 name = "zerobox-utils-string"
-version = "0.3.1"
+version = "0.3.3"
 dependencies = [
  "pretty_assertions",
  "regex-lite",
@@ -3979,7 +3979,7 @@ dependencies = [
 
 [[package]]
 name = "zerobox-windows-sandbox"
-version = "0.3.1"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "base64",

--- a/README.md
+++ b/README.md
@@ -241,6 +241,7 @@ Sandbox overhead is minimal, typically ~10ms and ~7MB:
 | `--deny-env <keys>`             | `--deny-env=SECRET`                    | Drop these parent env vars. Takes precedence over `--allow-env`.                                             |
 | `--secret <KEY=VALUE>`          | `--secret API_KEY=sk-123`              | Pass a secret. The process sees a placeholder. The real value is injected at the proxy for approved hosts.   |
 | `--secret-host <KEY=HOSTS>`     | `--secret-host API_KEY=api.openai.com` | Restrict a secret to specific hosts. Without this, the secret is substituted for all hosts.                  |
+| `--bind-mount <HOST:SANDBOX[:ro]>` | `--bind-mount /tmp/proj-abc:/tmp` | Remap a host directory onto a path inside the sandbox. Repeatable; mounts apply in argv order. Read-only with the `:ro` suffix. macOS, Windows, and WSL1 warn once per flag and run without remapping. |
 | `-A`, `--allow-all`             | `-A`                                   | Grant all filesystem and network permissions. Env and secrets still apply.                                   |
 | `--no-sandbox`                  | `--no-sandbox`                         | Disable the sandbox entirely.                                                                                |
 | `--strict-sandbox`              | `--strict-sandbox`                     | Require full sandbox (bubblewrap). Fail instead of falling back to weaker isolation.                         |

--- a/crates/zerobox/README.md
+++ b/crates/zerobox/README.md
@@ -35,6 +35,23 @@ println!("{}", String::from_utf8_lossy(&output.stdout));
 println!("exit: {}", output.status);
 ```
 
+## Bind mounts
+
+Give the sandboxed process a private view of a directory by remapping a host
+path to a different path inside the sandbox. Useful for per-project tmpdirs:
+
+```rust
+let output = Sandbox::command("node")
+    .arg("app.js")
+    .bind_mount("/tmp/projects/abc123", "/tmp")     // writable
+    .bind_mount_ro("/var/cache/pkg", "/var/cache/pkg") // read-only
+    .run()
+    .await?;
+```
+
+Mounts apply in the order declared. macOS, Windows, and WSL1 emit a one-line
+warning and run without remapping.
+
 ## Execution modes
 
 ### Collect output
@@ -152,6 +169,7 @@ let output = Sandbox::command("ls")
 | `env(k, v)` | Set an env var. |
 | `allow_env(keys)` / `deny_env(keys)` | Inherit / block parent env vars. |
 | `secret(k, v)` / `secret_host(k, hosts)` | Secret and its allowed hosts. |
+| `bind_mount(host, sandbox)` / `bind_mount_ro(host, sandbox)` | Remap a host directory to a sandbox path. Linux-only; macOS/Windows/WSL1 warn and no-op. |
 | `profile(name)` / `profiles(names)` / `no_profile()` | Select or skip profiles. |
 | `full_access()` / `no_sandbox()` / `strict_sandbox()` | Coarse policy switches. |
 | `snapshot()` / `restore()` | Record / roll back filesystem changes. |

--- a/crates/zerobox/src/main.rs
+++ b/crates/zerobox/src/main.rs
@@ -82,8 +82,44 @@ pub struct Cli {
     #[arg(long = "snapshot-exclude", value_delimiter = ',', num_args = 1..)]
     pub snapshot_exclude: Option<Vec<String>>,
 
+    /// Remap a host directory to a path inside the sandbox.
+    ///
+    /// Format: `HOST:SANDBOX[:ro]`. Repeatable; mounts apply in argv order.
+    /// macOS, Windows, and WSL1 emit a warning and run without remapping.
+    #[arg(long = "bind-mount", value_name = "HOST:SANDBOX[:ro]")]
+    pub bind_mount: Vec<String>,
+
     #[arg(trailing_var_arg = true)]
     pub command: Vec<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ParsedBindMount {
+    pub host: PathBuf,
+    pub sandbox: PathBuf,
+    pub read_only: bool,
+}
+
+/// Parse a `--bind-mount HOST:SANDBOX[:ro]` value.
+pub fn parse_bind_mount_arg(value: &str) -> Result<ParsedBindMount, String> {
+    let (host, rest) = value
+        .split_once(':')
+        .ok_or_else(|| "expected HOST:SANDBOX[:ro]".to_string())?;
+    if host.is_empty() {
+        return Err("HOST is empty".to_string());
+    }
+    let (sandbox, read_only) = match rest.rsplit_once(':') {
+        Some((sandbox, "ro")) => (sandbox, true),
+        _ => (rest, false),
+    };
+    if sandbox.is_empty() {
+        return Err("SANDBOX is empty".to_string());
+    }
+    Ok(ParsedBindMount {
+        host: PathBuf::from(host),
+        sandbox: PathBuf::from(sandbox),
+        read_only,
+    })
 }
 
 #[derive(Subcommand, Debug)]
@@ -300,6 +336,22 @@ async fn tokio_main(cli: Cli, linux_sandbox_exe: Option<PathBuf>) -> ExitCode {
         }
     }
 
+    for raw in &cli.bind_mount {
+        match parse_bind_mount_arg(raw) {
+            Ok(mount) => {
+                sandbox = if mount.read_only {
+                    sandbox.bind_mount_ro(mount.host, mount.sandbox)
+                } else {
+                    sandbox.bind_mount(mount.host, mount.sandbox)
+                };
+            }
+            Err(err) => {
+                eprintln!("error: invalid --bind-mount value '{raw}': {err}");
+                return ExitCode::from(1);
+            }
+        }
+    }
+
     debug_log!(
         dbg,
         "cwd: {:?}",
@@ -404,4 +456,64 @@ async fn tokio_main(cli: Cli, linux_sandbox_exe: Option<PathBuf>) -> ExitCode {
     }
 
     exit
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::Parser;
+
+    #[test]
+    fn parse_bind_mount_arg_without_ro() {
+        let parsed = parse_bind_mount_arg("/host/a:/sandbox/a").unwrap();
+        assert_eq!(parsed.host, PathBuf::from("/host/a"));
+        assert_eq!(parsed.sandbox, PathBuf::from("/sandbox/a"));
+        assert!(!parsed.read_only);
+    }
+
+    #[test]
+    fn parse_bind_mount_arg_with_ro() {
+        let parsed = parse_bind_mount_arg("/host/a:/sandbox/a:ro").unwrap();
+        assert_eq!(parsed.host, PathBuf::from("/host/a"));
+        assert_eq!(parsed.sandbox, PathBuf::from("/sandbox/a"));
+        assert!(parsed.read_only);
+    }
+
+    #[test]
+    fn parse_bind_mount_arg_empty_host_is_error() {
+        assert!(parse_bind_mount_arg(":/sandbox").is_err());
+    }
+
+    #[test]
+    fn parse_bind_mount_arg_empty_sandbox_is_error() {
+        assert!(parse_bind_mount_arg("/host:").is_err());
+    }
+
+    #[test]
+    fn parse_bind_mount_arg_without_separator_is_error() {
+        assert!(parse_bind_mount_arg("just-a-path").is_err());
+    }
+
+    #[test]
+    fn cli_repeated_bind_mount_preserves_order() {
+        let cli = Cli::parse_from([
+            "zerobox",
+            "--bind-mount",
+            "/host/a:/sandbox/a",
+            "--bind-mount",
+            "/host/b:/sandbox/b:ro",
+            "--bind-mount",
+            "/host/c:/sandbox/c",
+            "--",
+            "true",
+        ]);
+        assert_eq!(
+            cli.bind_mount,
+            vec![
+                "/host/a:/sandbox/a".to_string(),
+                "/host/b:/sandbox/b:ro".to_string(),
+                "/host/c:/sandbox/c".to_string(),
+            ]
+        );
+    }
 }

--- a/crates/zerobox/src/sandbox.rs
+++ b/crates/zerobox/src/sandbox.rs
@@ -14,7 +14,8 @@ use zerobox_protocol::permissions::{
 #[cfg(test)]
 use zerobox_protocol::protocol::SandboxPolicy;
 use zerobox_sandboxing::{
-    SandboxCommand, SandboxManager, SandboxTransformRequest, SandboxType, get_platform_sandbox,
+    BindMount, SandboxCommand, SandboxManager, SandboxTransformRequest, SandboxType,
+    get_platform_sandbox, validate_bind_mount,
 };
 use zerobox_utils_absolute_path::AbsolutePathBuf;
 
@@ -72,6 +73,7 @@ pub struct Sandbox {
     profile_names: Vec<String>,
     use_profile: bool,
     linux_sandbox_exe: Option<PathBuf>,
+    bind_mounts: Vec<BindMount>,
 }
 
 impl Sandbox {
@@ -99,6 +101,7 @@ impl Sandbox {
             profile_names: Vec::new(),
             use_profile: true,
             linux_sandbox_exe: None,
+            bind_mounts: Vec::new(),
         }
     }
 
@@ -235,6 +238,31 @@ impl Sandbox {
         self
     }
 
+    /// Remap a host directory to a path inside the sandbox.
+    ///
+    /// The host directory's contents become visible at the sandbox path; the
+    /// original sandbox path is hidden from the sandboxed process. The bind
+    /// mount is implicitly readable and writable — you do not also need to
+    /// pass `allow_read` / `allow_write` for the sandbox path.
+    ///
+    /// `sandbox` must be an absolute path and may not target `/`, `/proc`,
+    /// `/sys`, or `/dev`. Multiple bind mounts are applied in the order they
+    /// are declared so parents can be mounted before children.
+    ///
+    /// Only Linux/WSL2 honor bind mounts. macOS, Windows, and WSL1 emit a
+    /// one-line warning to stderr and run the command without remapping.
+    pub fn bind_mount(mut self, host: impl Into<PathBuf>, sandbox: impl Into<PathBuf>) -> Self {
+        self.bind_mounts.push(BindMount::new(host, sandbox));
+        self
+    }
+
+    /// Same as [`Sandbox::bind_mount`] but the mount is read-only inside the
+    /// sandbox.
+    pub fn bind_mount_ro(mut self, host: impl Into<PathBuf>, sandbox: impl Into<PathBuf>) -> Self {
+        self.bind_mounts.push(BindMount::new_ro(host, sandbox));
+        self
+    }
+
     /// Set the Linux sandbox helper executable.
     ///
     /// This is only used on Linux. Embedders that call zerobox from their own
@@ -340,6 +368,7 @@ impl Sandbox {
             profile_names,
             use_profile,
             linux_sandbox_exe,
+            bind_mounts,
         } = self;
 
         let cwd = match cwd {
@@ -385,6 +414,25 @@ impl Sandbox {
         if !full_access {
             validate_paths(&allow_read, &deny_read, &allow_write, &deny_write, &cwd)?;
         }
+
+        let bind_mounts = if bind_mounts.is_empty() {
+            bind_mounts
+        } else if disabled || full_access {
+            warn_bind_mounts_ignored(&bind_mounts, "because the sandbox is disabled");
+            Vec::new()
+        } else if !bind_mounts_supported_on_platform() {
+            warn_bind_mounts_ignored(
+                &bind_mounts,
+                &format!("on {}", bind_mount_unsupported_platform_label()),
+            );
+            Vec::new()
+        } else {
+            for mount in &bind_mounts {
+                validate_bind_mount(mount)
+                    .map_err(|e| anyhow::anyhow!("invalid --bind-mount: {e}"))?;
+            }
+            bind_mounts
+        };
 
         let secret_store = Arc::new(
             secret::build_secret_store(&secrets, &secret_hosts).map_err(|e| anyhow::anyhow!(e))?,
@@ -468,6 +516,7 @@ impl Sandbox {
                 use_legacy_landlock,
                 windows_sandbox_level: WindowsSandboxLevel::default(),
                 windows_sandbox_private_desktop: false,
+                bind_mounts,
             })
             .map_err(|e| anyhow::anyhow!("sandbox transform failed: {e}"))?;
 
@@ -977,6 +1026,81 @@ fn select_sandbox_type(strict: bool) -> Result<(SandboxType, bool)> {
     }
 }
 
+fn program_name_for_warning() -> String {
+    std::env::args_os()
+        .next()
+        .and_then(|os| {
+            std::path::PathBuf::from(os)
+                .file_name()
+                .map(|name| name.to_string_lossy().into_owned())
+        })
+        .unwrap_or_else(|| "zerobox".to_string())
+}
+
+fn warn_bind_mounts_ignored(bind_mounts: &[BindMount], reason: &str) {
+    for mount in bind_mounts {
+        eprintln!(
+            "{}: --bind-mount is a no-op {reason}; {} not remapped",
+            program_name_for_warning(),
+            mount.host.display(),
+        );
+    }
+}
+
+fn bind_mount_unsupported_platform_label() -> &'static str {
+    #[cfg(target_os = "macos")]
+    {
+        "macOS"
+    }
+    #[cfg(target_os = "windows")]
+    {
+        "Windows"
+    }
+    #[cfg(target_os = "linux")]
+    {
+        if is_wsl1() { "WSL1" } else { "this platform" }
+    }
+    #[cfg(not(any(target_os = "macos", target_os = "windows", target_os = "linux")))]
+    {
+        "this platform"
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn bind_mounts_supported_on_platform() -> bool {
+    !is_wsl1()
+}
+
+#[cfg(not(target_os = "linux"))]
+fn bind_mounts_supported_on_platform() -> bool {
+    false
+}
+
+#[cfg(target_os = "linux")]
+fn is_wsl1() -> bool {
+    std::fs::read_to_string("/proc/version")
+        .map(|contents| proc_version_indicates_wsl1(&contents))
+        .unwrap_or(false)
+}
+
+#[cfg(target_os = "linux")]
+fn proc_version_indicates_wsl1(proc_version: &str) -> bool {
+    let lower = proc_version.to_ascii_lowercase();
+    let mut remaining = lower.as_str();
+    while let Some(marker) = remaining.find("wsl") {
+        let version_start = marker + "wsl".len();
+        let digits: String = remaining[version_start..]
+            .chars()
+            .take_while(char::is_ascii_digit)
+            .collect();
+        if let Ok(version) = digits.parse::<u32>() {
+            return version == 1;
+        }
+        remaining = &remaining[version_start..];
+    }
+    lower.contains("microsoft") && !lower.contains("microsoft-standard")
+}
+
 #[cfg(target_os = "linux")]
 fn can_create_user_namespace() -> bool {
     use std::process::Command;
@@ -1432,6 +1556,39 @@ mod tests {
         let s = Sandbox::command("x").linux_sandbox_exe(p("/tmp/zerobox-linux-sandbox"));
 
         assert_eq!(s.linux_sandbox_exe, Some(p("/tmp/zerobox-linux-sandbox")));
+    }
+
+    #[test]
+    fn builder_bind_mount_accumulates_in_order() {
+        let s = Sandbox::command("x")
+            .bind_mount("/host/a", "/sandbox/a")
+            .bind_mount_ro("/host/b", "/sandbox/b")
+            .bind_mount("/host/c", "/sandbox/c");
+
+        let hosts: Vec<_> = s.bind_mounts.iter().map(|m| m.host.clone()).collect();
+        let sandboxes: Vec<_> = s.bind_mounts.iter().map(|m| m.sandbox.clone()).collect();
+        let ro: Vec<bool> = s.bind_mounts.iter().map(|m| m.read_only).collect();
+        assert_eq!(hosts, vec![p("/host/a"), p("/host/b"), p("/host/c")]);
+        assert_eq!(
+            sandboxes,
+            vec![p("/sandbox/a"), p("/sandbox/b"), p("/sandbox/c")]
+        );
+        assert_eq!(ro, vec![false, true, false]);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn proc_version_wsl1_detection() {
+        assert!(proc_version_indicates_wsl1(
+            "Linux version 4.4.0-19041-Microsoft (Microsoft@Microsoft.com) (gcc..."
+        ));
+        assert!(!proc_version_indicates_wsl1(
+            "Linux version 5.15.0-microsoft-standard-WSL2"
+        ));
+        assert!(!proc_version_indicates_wsl1("Linux version 6.5.0-generic"));
+        assert!(proc_version_indicates_wsl1(
+            "Linux version 4.4.0-WSL1-Microsoft"
+        ));
     }
 
     // apply_profile

--- a/crates/zerobox/tests/sandbox/bind_mount.rs
+++ b/crates/zerobox/tests/sandbox/bind_mount.rs
@@ -1,0 +1,174 @@
+use crate::support::*;
+
+/// End-to-end tests for `--bind-mount`.
+///
+/// The sandbox runtime requires user-namespace privileges that are not
+/// available in every CI environment; tests probe the actual bwrap path and
+/// skip if the host is unable to set up the loopback / user namespace. CI
+/// running with namespaces enabled exercises the real mount.
+fn user_namespaces_available() -> bool {
+    let out = run(&["--", "true"]);
+    !stderr(&out).contains("Failed RTM_NEWADDR")
+        && !stderr(&out).contains("No permissions to create a new namespace")
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn bind_mount_exposes_host_contents_at_sandbox_path() {
+    if !user_namespaces_available() {
+        return;
+    }
+    let src = tempfile::tempdir().expect("src dir");
+    let dst_parent = tempfile::tempdir().expect("dst parent");
+    let dst = dst_parent.path().join("destination-target");
+    std::fs::create_dir_all(&dst).expect("create dst placeholder");
+    let marker = src.path().join("marker.txt");
+    std::fs::write(&marker, b"hello-from-host").expect("write marker");
+
+    let spec = format!("{}:{}", src.path().display(), dst.display());
+    let probe = format!("cat {}/marker.txt", dst.display());
+    let out = run(&[
+        "--bind-mount",
+        &spec,
+        "--allow-read",
+        dst.to_str().unwrap(),
+        "--",
+        "sh",
+        "-c",
+        &probe,
+    ]);
+    assert!(
+        out.status.success(),
+        "stderr: {}\nstdout: {}",
+        stderr(&out),
+        stdout(&out)
+    );
+    assert_eq!(stdout(&out).trim(), "hello-from-host");
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn bind_mount_read_only_rejects_writes() {
+    if !user_namespaces_available() {
+        return;
+    }
+    let src = tempfile::tempdir().expect("src dir");
+    let dst_parent = tempfile::tempdir().expect("dst parent");
+    let dst = dst_parent.path().join("ro-dst");
+    std::fs::create_dir_all(&dst).expect("create dst placeholder");
+    let spec = format!("{}:{}:ro", src.path().display(), dst.display());
+    let cmd = format!(
+        "echo nope > {}/file && echo OK || echo BLOCKED",
+        dst.display()
+    );
+    let out = run(&[
+        "--bind-mount",
+        &spec,
+        "--allow-read",
+        dst.to_str().unwrap(),
+        "--",
+        "sh",
+        "-c",
+        &cmd,
+    ]);
+    assert!(
+        stdout(&out).contains("BLOCKED"),
+        "ro bind mount should reject writes; stdout: {}, stderr: {}",
+        stdout(&out),
+        stderr(&out)
+    );
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn bind_mount_forbidden_roots_rejected_before_spawn() {
+    let src = tempfile::tempdir().expect("src dir");
+    for forbidden in &["/", "/proc", "/sys", "/dev"] {
+        let spec = format!("{}:{}", src.path().display(), forbidden);
+        let out = run(&["--bind-mount", &spec, "--", "true"]);
+        assert!(
+            !out.status.success(),
+            "expected forbidden root {forbidden} to be rejected; stderr: {}",
+            stderr(&out),
+        );
+        assert!(
+            stderr(&out).contains("--bind-mount") && stderr(&out).contains("forbidden"),
+            "expected clear forbidden-root error for {forbidden}, got: {}",
+            stderr(&out),
+        );
+    }
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn bind_mount_missing_host_dir_rejected_before_spawn() {
+    let spec = "/nonexistent/path/for/bind/mount/test:/tmp/dst-missing";
+    let out = run(&["--bind-mount", spec, "--", "true"]);
+    assert!(
+        !out.status.success(),
+        "missing host dir should be rejected; stderr: {}",
+        stderr(&out)
+    );
+    assert!(
+        stderr(&out).contains("does not exist"),
+        "missing host dir error not surfaced, got: {}",
+        stderr(&out)
+    );
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn bind_mount_relative_sandbox_path_rejected() {
+    let src = tempfile::tempdir().expect("src dir");
+    let spec = format!("{}:relative/path", src.path().display());
+    let out = run(&["--bind-mount", &spec, "--", "true"]);
+    assert!(
+        !out.status.success(),
+        "relative SANDBOX should be rejected; stderr: {}",
+        stderr(&out)
+    );
+    assert!(
+        stderr(&out).contains("absolute"),
+        "expected absolute-path error, got: {}",
+        stderr(&out)
+    );
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn bind_mount_host_file_not_directory_rejected() {
+    let src = tempfile::tempdir().expect("src dir");
+    let file = src.path().join("regular-file");
+    std::fs::write(&file, b"x").expect("write file");
+    let spec = format!("{}:/tmp/dst-file-bind", file.display());
+    let out = run(&["--bind-mount", &spec, "--", "true"]);
+    assert!(
+        !out.status.success(),
+        "non-directory host should be rejected; stderr: {}",
+        stderr(&out)
+    );
+    assert!(
+        stderr(&out).contains("not a directory"),
+        "expected not-a-directory error, got: {}",
+        stderr(&out)
+    );
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn bind_mount_warns_and_runs_on_macos() {
+    let src = tempfile::tempdir().expect("src dir");
+    let spec = format!("{}:/tmp/dst-macos", src.path().display());
+    let out = run(&["--bind-mount", &spec, "--", "echo", "hello"]);
+    assert!(
+        out.status.success(),
+        "command should still run; stderr: {}",
+        stderr(&out)
+    );
+    assert!(
+        stderr(&out).contains("--bind-mount is a no-op") && stderr(&out).contains("macOS"),
+        "expected macOS no-op warning, got: {}",
+        stderr(&out)
+    );
+    assert_eq!(stdout(&out).trim(), "hello");
+}

--- a/crates/zerobox/tests/sandbox/mod.rs
+++ b/crates/zerobox/tests/sandbox/mod.rs
@@ -1,3 +1,4 @@
+mod bind_mount;
 mod env;
 mod misc;
 mod net;

--- a/packages/zerobox/README.md
+++ b/packages/zerobox/README.md
@@ -85,6 +85,26 @@ try {
 }
 ```
 
+## Bind mounts
+
+Give the sandboxed process a private view of a directory by remapping a host
+path to a different path inside the sandbox. Useful for per-project tmpdirs:
+
+```ts
+const sandbox = Sandbox.create({
+  bindMounts: [
+    { host: "/tmp/projects/abc123", sandbox: "/tmp" },
+    { host: "/var/cache/pkg", sandbox: "/var/cache/pkg", readOnly: true },
+  ],
+});
+
+await sandbox.sh`node app.js`.text();
+```
+
+Mounts apply in the order declared, so list parents before children. On Linux
+(and WSL2) the CLI performs a real bind mount; on macOS, Windows, and WSL1 it
+emits a one-line warning to stderr and runs the command without remapping.
+
 ## Secrets
 
 Pass API keys that the sandboxed process never sees. The proxy substitutes the real value only for approved hosts.
@@ -177,6 +197,7 @@ See the [main README](https://github.com/afshinm/zerobox#environment-variables) 
 | `restore` | `boolean` | Record and roll back after exit. Implies `snapshot`. |
 | `snapshotPaths` / `snapshotExclude` | `string[]` | Tracked paths / excluded patterns. |
 | `secrets` | `Record<string, SecretConfig>` | Secrets with per-host scopes. |
+| `bindMounts` | `BindMount[]` | Remap host directories onto sandbox paths. Linux/WSL2 real mount; macOS/Windows/WSL1 warn and no-op. |
 | `debug` | `boolean` | Print sandbox config to stderr. |
 
 ## Caveats

--- a/packages/zerobox/src/flags.test.ts
+++ b/packages/zerobox/src/flags.test.ts
@@ -253,4 +253,81 @@ describe("buildFlags", () => {
     const flags = buildFlags({ allowEnv: [] });
     expect(flags).not.toContain("--allow-env");
   });
+
+  // bind mounts
+
+  it("emits a single --bind-mount entry", () => {
+    const flags = buildFlags({
+      bindMounts: [{ host: "/tmp/proj-abc", sandbox: "/tmp" }],
+    });
+    expect(flags).toContain("--bind-mount");
+    expect(flags).toContain("/tmp/proj-abc:/tmp");
+  });
+
+  it("appends :ro for read-only mounts", () => {
+    const flags = buildFlags({
+      bindMounts: [{ host: "/var/cache/pkg", sandbox: "/var/cache/pkg", readOnly: true }],
+    });
+    expect(flags).toContain("--bind-mount");
+    expect(flags).toContain("/var/cache/pkg:/var/cache/pkg:ro");
+  });
+
+  it("preserves Windows drive-letter paths", () => {
+    const flags = buildFlags({
+      bindMounts: [
+        {
+          host: String.raw`C:\host\a`,
+          sandbox: String.raw`D:\sandbox\a`,
+          readOnly: true,
+        },
+      ],
+    });
+    expect(flags).toContain(String.raw`C:\host\a:D:\sandbox\a:ro`);
+  });
+
+  it("preserves argv order across multiple mounts", () => {
+    const flags = buildFlags({
+      bindMounts: [
+        { host: "/host/a", sandbox: "/a" },
+        { host: "/host/b", sandbox: "/a/b", readOnly: true },
+        { host: "/host/c", sandbox: "/c" },
+      ],
+    });
+    // Collect the spec values that follow each --bind-mount flag.
+    const specs: string[] = [];
+    for (let i = 0; i < flags.length; i++) {
+      if (flags[i] === "--bind-mount") {
+        const next = flags[i + 1];
+        if (next !== undefined) {
+          specs.push(next);
+        }
+      }
+    }
+    expect(specs).toEqual(["/host/a:/a", "/host/b:/a/b:ro", "/host/c:/c"]);
+  });
+
+  it("omits --bind-mount when bindMounts is missing or empty", () => {
+    expect(buildFlags({}).filter((f) => f === "--bind-mount").length).toBe(0);
+    expect(buildFlags({ bindMounts: [] }).filter((f) => f === "--bind-mount").length).toBe(0);
+  });
+
+  it("bind mounts coexist with allowAll", () => {
+    const flags = buildFlags({
+      allowAll: true,
+      bindMounts: [{ host: "/host", sandbox: "/sandbox" }],
+    });
+    expect(flags).toContain("--allow-all");
+    expect(flags).toContain("--bind-mount");
+    expect(flags).toContain("/host:/sandbox");
+  });
+
+  it("bind mounts coexist with noSandbox", () => {
+    const flags = buildFlags({
+      noSandbox: true,
+      bindMounts: [{ host: "/host", sandbox: "/sandbox", readOnly: true }],
+    });
+    expect(flags).toContain("--no-sandbox");
+    expect(flags).toContain("--bind-mount");
+    expect(flags).toContain("/host:/sandbox:ro");
+  });
 });

--- a/packages/zerobox/src/flags.ts
+++ b/packages/zerobox/src/flags.ts
@@ -90,6 +90,13 @@ export function buildFlags(options: SandboxOptions): string[] {
     }
   }
 
+  if (options.bindMounts?.length) {
+    for (const m of options.bindMounts) {
+      const spec = m.readOnly ? `${m.host}:${m.sandbox}:ro` : `${m.host}:${m.sandbox}`;
+      flags.push("--bind-mount", spec);
+    }
+  }
+
   if (options.cwd) {
     flags.push("-C", options.cwd);
   }

--- a/packages/zerobox/src/index.ts
+++ b/packages/zerobox/src/index.ts
@@ -3,4 +3,10 @@ export { ShellCommand } from "./command.js";
 export { SandboxCommandError } from "./errors.js";
 export { buildFlags } from "./flags.js";
 export { resolveBinary } from "./binary.js";
-export type { SandboxOptions, SecretConfig, CommandOutput, CommandOptions } from "./types.js";
+export type {
+  SandboxOptions,
+  SecretConfig,
+  BindMount,
+  CommandOutput,
+  CommandOptions,
+} from "./types.js";

--- a/packages/zerobox/src/types.ts
+++ b/packages/zerobox/src/types.ts
@@ -47,6 +47,13 @@ export interface SandboxOptions {
    * in the sandbox. The hosts are merged into network permissions.
    */
   secrets?: Record<string, SecretConfig>;
+  /**
+   * Remap host directories onto sandbox paths. Entries apply in argv order,
+   * so declare parents before children. On Linux (and WSL2) the CLI performs
+   * a real bind mount; on macOS, Windows, and WSL1 the CLI emits a one-line
+   * warning to stderr and runs the command without remapping.
+   */
+  bindMounts?: BindMount[];
 }
 
 /** Configuration for a secret passed to the sandbox. */
@@ -55,6 +62,16 @@ export interface SecretConfig {
   value: string;
   /** Domains where this secret is needed. Merged into allowNet. */
   hosts: string[];
+}
+
+/** A single host→sandbox path remapping. */
+export interface BindMount {
+  /** Source path on the host. */
+  host: string;
+  /** Destination path inside the sandbox. The original contents are hidden. */
+  sandbox: string;
+  /** Mount read-only inside the sandbox. */
+  readOnly?: boolean;
 }
 
 /** Raw output from a sandboxed command. */

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -106,6 +106,26 @@ except SandboxCommandError as e:
     print(e.code, e.stderr)
 ```
 
+## Bind mounts
+
+Give the sandboxed process a private view of a directory by remapping a host
+path to a different path inside the sandbox. Useful for per-project tmpdirs:
+
+```python
+sandbox = Sandbox.create({
+    "bind_mounts": [
+        {"host": "/tmp/projects/abc123", "sandbox": "/tmp"},
+        {"host": "/var/cache/pkg", "sandbox": "/var/cache/pkg", "read_only": True},
+    ],
+})
+
+sandbox.sh("node app.js").text()
+```
+
+Mounts apply in the order declared, so list parents before children. On Linux
+(and WSL2) the CLI performs a real bind mount; on macOS, Windows, and WSL1 it
+emits a one-line warning to stderr and runs the command without remapping.
+
 ## Secrets
 
 Pass API keys that the sandboxed process never sees. The proxy substitutes the real value only for approved hosts.
@@ -201,6 +221,7 @@ See the [main README](https://github.com/afshinm/zerobox#environment-variables) 
 | `restore` | `bool` | Record and roll back after exit. Implies `snapshot`. |
 | `snapshot_paths` / `snapshot_exclude` | `list[str]` | Tracked paths / excluded patterns. |
 | `secrets` | `dict[str, SecretConfig]` | Secrets with per-host scopes. |
+| `bind_mounts` | `list[BindMount]` | Remap host directories onto sandbox paths. Linux/WSL2 real mount; macOS/Windows/WSL1 warn and no-op. |
 | `debug` | `bool` | Print sandbox config to stderr. |
 
 Unknown dict keys (e.g. accidental `allowWrite` instead of `allow_write`) raise `TypeError` at construction time.

--- a/sdks/python/src/zerobox/__init__.py
+++ b/sdks/python/src/zerobox/__init__.py
@@ -4,7 +4,7 @@ from .binary import async_verify_binary, resolve_binary, verify_binary
 from .command import AsyncShellCommand, ShellCommand
 from .errors import SandboxCommandError
 from .flags import build_flags
-from .options import CommandOutput, SandboxOptions, SecretConfig
+from .options import BindMount, CommandOutput, SandboxOptions, SecretConfig
 from .sandbox import AsyncSandbox, Sandbox
 
 try:
@@ -15,6 +15,7 @@ except PackageNotFoundError:
 __all__ = [
     "AsyncSandbox",
     "AsyncShellCommand",
+    "BindMount",
     "CommandOutput",
     "Sandbox",
     "SandboxCommandError",

--- a/sdks/python/src/zerobox/flags.py
+++ b/sdks/python/src/zerobox/flags.py
@@ -72,6 +72,11 @@ def build_flags(options: Union[SandboxOptions, dict[str, Any], None]) -> list[st
         for key, value in o.env.items():
             flags.extend(["--env", f"{key}={value}"])
 
+    if o.bind_mounts:
+        for m in o.bind_mounts:
+            spec = f"{m.host}:{m.sandbox}:ro" if m.read_only else f"{m.host}:{m.sandbox}"
+            flags.extend(["--bind-mount", spec])
+
     if o.cwd:
         flags.extend(["-C", o.cwd])
 

--- a/sdks/python/src/zerobox/options.py
+++ b/sdks/python/src/zerobox/options.py
@@ -11,6 +11,20 @@ class SecretConfig:
 
 
 @dataclass(frozen=True)
+class BindMount:
+    """A single host→sandbox path remapping.
+
+    On Linux (and WSL2) the CLI performs a real bind mount; on macOS,
+    Windows, and WSL1 the CLI emits a one-line warning to stderr and runs
+    the command without remapping.
+    """
+
+    host: str
+    sandbox: str
+    read_only: bool = False
+
+
+@dataclass(frozen=True)
 class CommandOutput:
     code: int
     stdout: str
@@ -38,6 +52,7 @@ class SandboxOptions:
     snapshot_paths: Union[list[str], None] = None
     snapshot_exclude: Union[list[str], None] = None
     secrets: Union[dict[str, SecretConfig], None] = None
+    bind_mounts: Union[list[BindMount], None] = None
     debug: bool = False
 
 
@@ -45,6 +60,16 @@ def _coerce_secret(cfg: Union[SecretConfig, dict[str, Any]]) -> SecretConfig:
     if isinstance(cfg, SecretConfig):
         return cfg
     return SecretConfig(value=cfg["value"], hosts=list(cfg.get("hosts") or []))
+
+
+def _coerce_bind_mount(mount: Union[BindMount, dict[str, Any]]) -> BindMount:
+    if isinstance(mount, BindMount):
+        return mount
+    return BindMount(
+        host=mount["host"],
+        sandbox=mount["sandbox"],
+        read_only=bool(mount.get("read_only", False)),
+    )
 
 
 def normalize_options(
@@ -63,4 +88,6 @@ def normalize_options(
     kwargs = dict(options)
     if kwargs.get("secrets"):
         kwargs["secrets"] = {k: _coerce_secret(v) for k, v in kwargs["secrets"].items()}
+    if kwargs.get("bind_mounts"):
+        kwargs["bind_mounts"] = [_coerce_bind_mount(m) for m in kwargs["bind_mounts"]]
     return SandboxOptions(**kwargs)

--- a/sdks/python/tests/test_flags.py
+++ b/sdks/python/tests/test_flags.py
@@ -275,3 +275,90 @@ def test_accepts_dataclass_and_dict_identically():
     dc = SandboxOptions(allow_write=["/tmp"], allow_net=["example.com"])
     dt = {"allow_write": ["/tmp"], "allow_net": ["example.com"]}
     assert build_flags(dc) == build_flags(dt)
+
+
+# bind mounts
+
+
+def test_bind_mount_single_entry():
+    flags = build_flags({"bind_mounts": [{"host": "/tmp/proj-abc", "sandbox": "/tmp"}]})
+    assert "--bind-mount" in flags
+    assert "/tmp/proj-abc:/tmp" in flags
+
+
+def test_bind_mount_read_only_appends_ro():
+    flags = build_flags(
+        {
+            "bind_mounts": [
+                {"host": "/var/cache/pkg", "sandbox": "/var/cache/pkg", "read_only": True}
+            ]
+        }
+    )
+    assert "--bind-mount" in flags
+    assert "/var/cache/pkg:/var/cache/pkg:ro" in flags
+
+
+def test_bind_mount_preserves_windows_drive_letter_paths():
+    flags = build_flags(
+        {
+            "bind_mounts": [
+                {
+                    "host": r"C:\host\a",
+                    "sandbox": r"D:\sandbox\a",
+                    "read_only": True,
+                }
+            ]
+        }
+    )
+    assert r"C:\host\a:D:\sandbox\a:ro" in flags
+
+
+def test_bind_mount_preserves_argv_order():
+    flags = build_flags(
+        {
+            "bind_mounts": [
+                {"host": "/host/a", "sandbox": "/a"},
+                {"host": "/host/b", "sandbox": "/a/b", "read_only": True},
+                {"host": "/host/c", "sandbox": "/c"},
+            ]
+        }
+    )
+    specs = [flags[i + 1] for i, f in enumerate(flags) if f == "--bind-mount"]
+    assert specs == ["/host/a:/a", "/host/b:/a/b:ro", "/host/c:/c"]
+
+
+def test_bind_mount_missing_or_empty_omits_flag():
+    assert "--bind-mount" not in build_flags({})
+    assert "--bind-mount" not in build_flags({"bind_mounts": []})
+
+
+def test_bind_mount_coexists_with_allow_all():
+    flags = build_flags(
+        {
+            "allow_all": True,
+            "bind_mounts": [{"host": "/host", "sandbox": "/sandbox"}],
+        }
+    )
+    assert "--allow-all" in flags
+    assert "--bind-mount" in flags
+    assert "/host:/sandbox" in flags
+
+
+def test_bind_mount_coexists_with_no_sandbox():
+    flags = build_flags(
+        {
+            "no_sandbox": True,
+            "bind_mounts": [{"host": "/host", "sandbox": "/sandbox", "read_only": True}],
+        }
+    )
+    assert "--no-sandbox" in flags
+    assert "--bind-mount" in flags
+    assert "/host:/sandbox:ro" in flags
+
+
+def test_bind_mount_accepts_dataclass():
+    from zerobox import BindMount, SandboxOptions
+
+    dc = SandboxOptions(bind_mounts=[BindMount(host="/h", sandbox="/s", read_only=True)])
+    dt = {"bind_mounts": [{"host": "/h", "sandbox": "/s", "read_only": True}]}
+    assert build_flags(dc) == build_flags(dt)


### PR DESCRIPTION
## Summary

*Disclosure:* I wrote this PR with Claude, reviewed it with Codex, fixed some changes, then re-reviewed with Claude.

Adds a `--bind-mount HOST:SANDBOX[:ro]` flag (repeatable) that remaps a host
directory onto a path inside the sandbox. The host directory's contents
become visible at the sandbox path; the original sandbox path is hidden from
the sandboxed process. The bind-mounted path is implicitly readable (and
writable, unless `:ro`) — callers don't need to also pass `--allow-read` or
`--allow-write` for the sandbox path.

Motivating use case: an AI coding harness wants to give each project a
private `/tmp` by setting up `/tmp/projects/<sha>` on the host and exposing
it as `/tmp` inside the sandbox. The agent sees `/tmp`; the host sees
per-project isolation. Mount namespaces make this transparent to the
process.

## CLI

```
zerobox --bind-mount /tmp/cockpit/abc123:/tmp -- node app.js
zerobox --bind-mount /var/cache/pkg:/var/cache/pkg:ro -- apt-get install ...
```

Repeatable; mounts are applied in argv order so callers can declare parents
before children.

## SDKs

```rust
Sandbox::command("node")
    .bind_mount("/tmp/projects/abc123", "/tmp")
    .bind_mount_ro("/var/cache/pkg", "/var/cache/pkg")
    .run().await?;
```

```ts
Sandbox.create({
  bindMounts: [
    { host: "/tmp/projects/abc123", sandbox: "/tmp" },
    { host: "/var/cache/pkg", sandbox: "/var/cache/pkg", readOnly: true },
  ],
});
```

```python
Sandbox(SandboxOptions(
    bind_mounts=[
        BindMount(host="/tmp/projects/abc123", sandbox="/tmp"),
        BindMount(host="/var/cache/pkg", sandbox="/var/cache/pkg", read_only=True),
    ],
))
```

## Platform behavior

| Platform     | Backend                              | Behavior                                             |
| ------------ | ------------------------------------ | ---------------------------------------------------- |
| Linux + WSL2 | Bubblewrap mount namespace           | Real bind mount via `--bind` / `--ro-bind`.          |
| macOS        | Seatbelt (no kernel mount support)   | Warn once per flag on stderr, run without remapping. |
| Windows      | Planned backend                      | Warn once per flag on stderr, run without remapping. |
| WSL1         | Cannot create nested user namespaces | Warn once per flag on stderr, run without remapping. |

Warning text: `--bind-mount is a no-op on <platform>; <HOST> not remapped`.
Emitted exactly once per `--bind-mount` flag, prefixed with the program name,
on stderr. Never emitted on Linux.

## Validation

All validation happens before bwrap is spawned, so misconfigured flags fail
fast with a clear error:

- `SANDBOX` must be absolute.
- `SANDBOX` may not be `/`, `/proc`, `/sys`, or `/dev` — those roots are
  already managed by the sandbox setup. Subdirectories of those roots are
  allowed (e.g. `/dev/shm/myapp`).
- `HOST` must exist and be a directory.

## Where the changes live

Trying to keep `upstream/sandboxing` and `upstream/linux-sandbox` diffs small
and localized, since `scripts/sync.sh` overwrites them on each codex sync.

- `upstream/sandboxing/src/bind_mount.rs` — new `BindMount` type +
  `validate_bind_mount` + forbidden-root list + `encode_bind_mount_for_cli`.
- `upstream/sandboxing/src/manager.rs` — `bind_mounts: Vec<BindMount>` field
  on `SandboxTransformRequest`, threaded into the helper CLI args.
- `upstream/sandboxing/src/landlock.rs` — emits `--bind-mount HOST:SANDBOX[:ro]`
  for each mount, after the existing helper flags and before `--`.
- `upstream/linux-sandbox/src/linux_run_main.rs` — accepts repeatable
  `--bind-mount` on the helper; refuses to silently drop mounts in the
  full-disk-write fast path or legacy-Landlock mode.
- `upstream/linux-sandbox/src/bwrap.rs` — `inject_bind_mounts` inserts
  `--bind` / `--ro-bind` after the policy mounts but before `--remount-ro`
  and `--chdir`, so the tmpfs root can still be sealed read-only and the
  mount order matches what the caller declared.
- `crates/zerobox/src/sandbox.rs` — `bind_mount` / `bind_mount_ro` builder
  methods, up-front validation, and the per-platform warning. WSL1 detection
  reuses the `/proc/version` heuristic from upstream.
- `crates/zerobox/src/main.rs` — `--bind-mount` CLI flag + value parser.
- `crates/zerobox/tests/sandbox/bind_mount.rs` — integration tests.
- `packages/zerobox/src/{types,flags,index}.ts`, `flags.test.ts` — TS SDK.
- `sdks/python/src/zerobox/{options,flags,__init__}.py`,
  `tests/test_flags.py` — Python SDK.
- `README.md`, `crates/zerobox/README.md`, `packages/zerobox/README.md`,
  `sdks/python/README.md` — docs.

## Out of scope

- Mount propagation flags (shared/slave/private). Default is bubblewrap's
  private propagation.
- Tmpfs mounts. Only bind mounts.
- Writable bind mounts on a read-only-root sandbox. The host source is
  assumed to be writable when `:ro` is not given.

## Test plan

- [x] `cargo build`
- [x] `cargo fmt -- --check`
- [x] `cargo clippy --workspace -- -D warnings`
- [x] `cargo test --workspace --lib` — all green
- [x] `cargo test -p zerobox --test integration -- sandbox::bind_mount` —
      6/6 pass on Linux. The two tests that exercise the real bwrap mount
      (`bind_mount_exposes_host_contents_at_sandbox_path` and
      `bind_mount_read_only_rejects_writes`) probe user-namespace support
      and skip in environments where bwrap can't initialize loopback; CI
      runners with namespaces enabled exercise the real mount.
- [x] TypeScript SDK: `pnpm test`, `pnpm lint`, `pnpm typecheck` clean.
- [x] Python SDK: `pytest`, `ruff check`, `ruff format --check`, `mypy` clean.

# Changeset

This is a new feature, so it should land as a minor bump. The repo uses
Changesets; add a file at `.changeset/<random-slug>.md` with:

```markdown
---
"@zerobox/cli-darwin-arm64": minor
"@zerobox/cli-darwin-x64": minor
"@zerobox/cli-linux-arm64": minor
"@zerobox/cli-linux-arm64-musl": minor
"@zerobox/cli-linux-x64": minor
"@zerobox/cli-linux-x64-musl": minor
"zerobox": minor
---

Add `--bind-mount HOST:SANDBOX[:ro]` to remap host paths into the sandbox.
```

The Python SDK ships through `scripts/prepare-python-wheels.sh` and does not
use changesets, so no entry is needed for it.