### PR TITLE
Fix seatbelt sandbox symlink handling for rules

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3771,7 +3771,7 @@ dependencies = [
 
 [[package]]
 name = "zerobox"
-version = "0.3.1"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3798,7 +3798,7 @@ dependencies = [
 
 [[package]]
 name = "zerobox-linux-sandbox"
-version = "0.3.1"
+version = "0.3.3"
 dependencies = [
  "clap",
  "globset",
@@ -3821,7 +3821,7 @@ dependencies = [
 
 [[package]]
 name = "zerobox-network-proxy"
-version = "0.3.1"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3852,14 +3852,14 @@ dependencies = [
 
 [[package]]
 name = "zerobox-otel"
-version = "0.3.1"
+version = "0.3.3"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "zerobox-process-hardening"
-version = "0.3.1"
+version = "0.3.3"
 dependencies = [
  "libc",
  "pretty_assertions",
@@ -3867,7 +3867,7 @@ dependencies = [
 
 [[package]]
 name = "zerobox-protocol"
-version = "0.3.1"
+version = "0.3.3"
 dependencies = [
  "globset",
  "pretty_assertions",
@@ -3884,7 +3884,7 @@ dependencies = [
 
 [[package]]
 name = "zerobox-sandboxing"
-version = "0.3.1"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3905,7 +3905,7 @@ dependencies = [
 
 [[package]]
 name = "zerobox-snapshot"
-version = "0.3.1"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "blake3",
@@ -3924,7 +3924,7 @@ dependencies = [
 
 [[package]]
 name = "zerobox-utils-absolute-path"
-version = "0.3.1"
+version = "0.3.3"
 dependencies = [
  "dirs",
  "dunce",
@@ -3938,7 +3938,7 @@ dependencies = [
 
 [[package]]
 name = "zerobox-utils-home-dir"
-version = "0.3.1"
+version = "0.3.3"
 dependencies = [
  "dirs",
  "zerobox-utils-absolute-path",
@@ -3946,7 +3946,7 @@ dependencies = [
 
 [[package]]
 name = "zerobox-utils-pty"
-version = "0.3.1"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "filedescriptor",
@@ -3962,14 +3962,14 @@ dependencies = [
 
 [[package]]
 name = "zerobox-utils-rustls-provider"
-version = "0.3.1"
+version = "0.3.3"
 dependencies = [
  "rustls",
 ]
 
 [[package]]
 name = "zerobox-utils-string"
-version = "0.3.1"
+version = "0.3.3"
 dependencies = [
  "pretty_assertions",
  "regex-lite",
@@ -3979,7 +3979,7 @@ dependencies = [
 
 [[package]]
 name = "zerobox-windows-sandbox"
-version = "0.3.1"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "base64",

--- a/UPSTREAM_VERSION
+++ b/UPSTREAM_VERSION
@@ -1,3 +1,3 @@
 rust-v0.131.0-alpha.22
 # commit: 9b8cf56cdefb09f54564ccc295fd42f6647f558f
-# synced: 2026-05-16T21:01:55Z
+# synced: 2026-06-11T19:24:07Z

--- a/crates/zerobox/src/sandbox.rs
+++ b/crates/zerobox/src/sandbox.rs
@@ -630,7 +630,7 @@ fn build_fs_policy(
         if let Ok(abs) = resolve_path(cwd, path) {
             entries.push(FileSystemSandboxEntry {
                 path: FileSystemPath::Path { path: abs },
-                access: FileSystemAccessMode::Read,
+                access: FileSystemAccessMode::None,
             });
         }
     }

--- a/scripts/sync.sh
+++ b/scripts/sync.sh
@@ -317,6 +317,12 @@ if [ -f "$BWRAP_FIXES_PATCH" ]; then
     patch -p0 < "$BWRAP_FIXES_PATCH"
 fi
 
+SEATBELT_SYMLINK_PATCH="$SCRIPT_DIR/upstream-seatbelt-symlink.patch"
+if [ -f "$SEATBELT_SYMLINK_PATCH" ]; then
+    echo "    seatbelt-symlink"
+    patch -p0 < "$SEATBELT_SYMLINK_PATCH"
+fi
+
 cd -
 
 {

--- a/scripts/upstream-seatbelt-symlink.patch
+++ b/scripts/upstream-seatbelt-symlink.patch
@@ -1,0 +1,48 @@
+--- upstream/sandboxing/src/seatbelt.rs
++++ upstream/sandboxing/src/seatbelt.rs
+@@ -17,6 +17,7 @@
+ use zerobox_protocol::protocol::SandboxPolicy;
+ use zerobox_protocol::protocol::WritableRoot;
+ use zerobox_utils_absolute_path::AbsolutePathBuf;
++use zerobox_utils_absolute_path::canonicalize_preserving_symlinks;
+ 
+ const MACOS_SEATBELT_BASE_POLICY: &str = include_str!("seatbelt_base_policy.sbpl");
+ const MACOS_SEATBELT_NETWORK_POLICY: &str = include_str!("seatbelt_network_policy.sbpl");
+@@ -160,9 +161,7 @@
+     }
+ 
+     let absolute_path = AbsolutePathBuf::from_absolute_path(path).ok()?;
+-    let normalized_path = absolute_path
+-        .as_path()
+-        .canonicalize()
++    let normalized_path = canonicalize_preserving_symlinks(absolute_path.as_path())
+         .ok()
+         .and_then(|canonical_path| AbsolutePathBuf::from_absolute_path(canonical_path).ok());
+     normalized_path.or(Some(absolute_path))
+@@ -458,9 +457,14 @@
+ fn canonicalize_glob_static_prefix_for_sandbox(pattern: &str) -> Option<String> {
+     let first_glob_index = pattern
+         .char_indices()
+         .find_map(|(index, ch)| matches!(ch, '*' | '?' | '[' | ']').then_some(index));
+     let Some(first_glob_index) = first_glob_index else {
+-        return normalize_path_for_sandbox(Path::new(pattern))
++        // For deny rules we always need the fully canonical path so the
++        // regex matches the resolved target regardless of how the user
++        // refers to it.
++        return Path::new(pattern)
++            .canonicalize()
++            .ok()
+             .map(|path| path.to_string_lossy().to_string());
+     };
+ 
+@@ -474,7 +479,9 @@
+         return None;
+     }
+ 
+-    let root = normalize_path_for_sandbox(Path::new(&pattern[..prefix_end]))?;
++    // For deny rules, always use the fully canonical path so the regex
++    // matches the resolved target behind any symlinks.
++    let root = AbsolutePathBuf::from_absolute_path(Path::new(&pattern[..prefix_end]).canonicalize().ok()?).ok()?;
+     let root = root.to_string_lossy();
+     let suffix = &pattern[prefix_end..];
+     let normalized_pattern = format!("{root}{suffix}");


### PR DESCRIPTION
**Problem:** When a file like `~/.gitconfig` is a symlink (e.g., pointing into a Dropbox folder), the seatbelt sandbox's path normalization was resolving through symlinks via `canonicalize()`. This meant the path written into the sandbox policy would be the *target* path rather than the symlink path the user specified, causing the rule to not match correctly.

**Changes:**
- **Preserve symlinks for allow rules:** `normalize_path_for_sandbox` now uses `canonicalize_preserving_symlinks` instead of `canonicalize()`, so symlink paths stay as-is when written into the seatbelt policy. This means a user-specified path like `~/.gitconfig` (a symlink) remains that way in the policy and matches correctly.
- **Fully resolve symlinks for deny rules:** `canonicalize_glob_static_prefix_for_sandbox` (used for deny rules) continues to use `canonicalize()` to resolve through symlinks. This ensures the deny regex matches the actual target regardless of how the user refers to it.
- **`FileSystemAccessMode::None` fallback:** Fix due to an upstream change.

**Additional thoughts**
Not sure if it would be worth opening a PR upstream as well...